### PR TITLE
Update react_example_theme.info.yml

### DIFF
--- a/drupal/web/themes/react_example_theme/react_example_theme.info.yml
+++ b/drupal/web/themes/react_example_theme/react_example_theme.info.yml
@@ -1,7 +1,7 @@
 name: React Example Theme
 type: theme
 description: 'A theme that loads React JavaScript libraries, and a basic React application.'
-core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 base theme: bartik
 
 libraries:


### PR DESCRIPTION
Update react_example_theme.info.yml to use `core_version_requirement: ^8.7.7 || ^9` instead of the deprecated (and removed in Drupal 9) `core` key.